### PR TITLE
Versteckte Systemvariablen auslesen

### DIFF
--- a/Systemvariablen/form.json
+++ b/Systemvariablen/form.json
@@ -25,6 +25,11 @@
             "name": "AlarmScriptID",
             "type": "SelectScript",
             "caption": "Alarmmanagement-Script"
+        },
+        {
+            "name": "ShowHidden",
+            "type": "CheckBox",
+            "caption": "show hidden system variables"
         }
     ],
     "status": [

--- a/Systemvariablen/locale.json
+++ b/Systemvariablen/locale.json
@@ -7,6 +7,7 @@
             "emulate state": "Status emulieren",
             "enable alarm variable": "Alarm-Variablen aktiv",
             "Alarmmanagement-Script": "Script für Alarmverarbeitung",
+            "show hidden system variables": "Versteckte Systemvariablen anzeigen",
             "Configuration is valid.": "Konfiguration gültig.",
             "No trigger or interval active.": "Kein Trigger oder Intervall aktiv.",
             "Interval to small.": "Intervall darf nicht kleiner 1 sein.",

--- a/Systemvariablen/module.php
+++ b/Systemvariablen/module.php
@@ -41,6 +41,7 @@ class HomeMaticSystemvariablen extends HMBase
         $this->RegisterPropertyBoolean('EmulateStatus', false);
         $this->RegisterPropertyBoolean('EnableAlarmDP', true);
         $this->RegisterPropertyInteger('AlarmScriptID', 0);
+        $this->RegisterPropertyBoolean('ShowHidden', false);
 
         $this->RegisterTimer('ReadHMSysVar', 0, 'HM_SystemVariablesTimer($_IPS[\'TARGET\']);');
         $this->HMDeviceAddress = '';
@@ -640,7 +641,11 @@ class HomeMaticSystemvariablen extends HMBase
     private function ReadSysVars()
     {
         // Systemvariablen
-        $HMScript = 'SysVars=dom.GetObject(ID_SYSTEM_VARIABLES).EnumUsedIDs();';
+        if ($this->ReadPropertyBoolean('ShowHidden')) {
+            $HMScript = 'SysVars=dom.GetObject(ID_SYSTEM_VARIABLES).EnumIDs();';
+        } else {
+            $HMScript = 'SysVars=dom.GetObject(ID_SYSTEM_VARIABLES).EnumUsedIDs();';
+        }
 
         try {
             $HMScriptResult = $this->LoadHMScript('SysVar.exe', $HMScript);


### PR DESCRIPTION
Erstmal danke für das nützliche Modul!

Bislang ist es nicht möglich die Totalwerte der Homematic IP Wetterstation HmIP-SWO-PR aus der CCU auszulesen. Ähnlich wie bei den Energiezählern werden diese als versteckte Systemvariablen angelegt und tauchen deshalb nicht unter den normalen Systemvariablen auf. Andere Werte, wie die Anzahl der Servicemeldungen und die Anzahl der Alarmmeldungen, sind außerdem auch versteckte Systemvariablen.

Dieser Patch ergänzt eine Checkbox mit der (optional) auch versteckte Systemvariablen ausgelesen werden können.